### PR TITLE
picker adapter to integrate snacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A Neovim plugin for quickly navigating YAML files using Telescope.
 
 ## Requirements
 
-- [Telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)
+- [Telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) or [Snacks.nvim](https://github.com/folke/snacks.nvim)
 - [Plenary.nvim](https://github.com/nvim-lua/plenary.nvim) (for multi-file search)
 - [lyaml](https://github.com/gvvaughan/lyaml) (optional, for improved YAML parsing)
 
@@ -95,6 +95,9 @@ require('yaml-jumper').setup({
     
     -- Parser settings
     use_smart_parser = true,           -- Use the enhanced YAML parser when available
+    
+    -- Picker settings
+    picker_type = "telescope",         -- Choose between "telescope" or "snacks"
     
     -- Debug settings
     debug_performance = false,         -- Enable performance profiling and logging

--- a/lua/yaml-jumper/picker.lua
+++ b/lua/yaml-jumper/picker.lua
@@ -1,0 +1,89 @@
+local M = {}
+
+-- Create a picker based on the configured type
+function M.create_picker(opts)
+    if config.picker_type == "telescope" then
+        return M.create_telescope_picker(opts)
+    else
+        return M.create_snacks_picker(opts)
+    end
+end
+
+-- Create a telescope picker
+function M.create_telescope_picker(opts)
+    local telescope = require("telescope.pickers")
+    local finders = require("telescope.finders")
+    local previewers = require("telescope.previewers")
+    local actions = require("telescope.actions")
+    local action_state = require("telescope.actions.state")
+    
+    return telescope.new(opts, {
+        prompt_title = opts.prompt_title,
+        finder = finders.new_table {
+            results = opts.results,
+            entry_maker = opts.entry_maker
+        },
+        sorter = require("telescope.config").values.generic_sorter({}),
+        previewer = opts.previewer,
+        attach_mappings = function(prompt_bufnr, map)
+            actions.select_default:replace(function()
+                actions.close(prompt_bufnr)
+                local selection = action_state.get_selected_entry()
+                if selection and opts.on_select then
+                    opts.on_select(selection)
+                end
+            end)
+            
+            if opts.on_attach then
+                opts.on_attach(prompt_bufnr, map)
+            end
+            
+            return true
+        end
+    })
+end
+
+-- Create a snacks picker
+function M.create_snacks_picker(opts)
+    local snacks = require("snacks")
+    
+    return snacks.picker.new({
+        prompt = opts.prompt_title,
+        finder = function()
+            local entries = {}
+            for _, item in ipairs(opts.results) do
+                local entry = opts.entry_maker(item)
+                table.insert(entries, {
+                    value = entry.value,
+                    display = entry.display,
+                    ordinal = entry.ordinal,
+                    filename = entry.filename,
+                    lnum = entry.lnum,
+                    text = entry.text,
+                    path = entry.path,
+                    value_text = entry.value_text
+                })
+            end
+            return entries
+        end,
+        previewer = function(entry)
+            if opts.previewer then
+                local preview_bufnr = vim.api.nvim_create_buf(false, true)
+                opts.previewer.define_preview({ state = { bufnr = preview_bufnr } }, entry, {})
+                return preview_bufnr
+            end
+        end,
+        on_select = function(selection)
+            if opts.on_select then
+                opts.on_select(selection)
+            end
+        end,
+        attach_mappings = function(map)
+            if opts.on_attach then
+                opts.on_attach(nil, map)
+            end
+        end
+    })
+end
+
+return M 


### PR DESCRIPTION
1. Added a new configuration option picker_type that can be set to either "telescope" or "snacks"
2. Created a new picker adapter module that provides a unified interface for both pickers
3. Updated the core jump functions to use the picker adapter
4. Updated the README to document the new configuration option